### PR TITLE
Use name of source file as output_name

### DIFF
--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -7788,8 +7788,8 @@ bool ir_gen_init(irGen *s, Checker *c) {
 	String init_fullpath = c->parser->init_fullpath;
 
 	if (build_context.out_filepath.len == 0) {
-		// s->output_name = filename_from_path(init_fullpath);
-		s->output_name = str_lit("main");
+		s->output_name = remove_directory_from_path(init_fullpath);
+		s->output_name = remove_extension_from_path(s->output_name);
 		s->output_base = s->output_name;
 	} else {
 		s->output_name = build_context.out_filepath;

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -276,6 +276,15 @@ String filename_from_path(String s) {
 	return make_string(nullptr, 0);
 }
 
+String remove_extension_from_path(String const &s) {
+	for (isize i = s.len-1; i >= 0; i--) {
+		if (s[i] == '.') {
+			return substring(s, 0, i);
+		}
+	}
+	return s;
+}
+
 String remove_directory_from_path(String const &s) {
 	isize len = 0;
 	for (isize i = s.len-1; i >= 0; i--) {
@@ -287,6 +296,7 @@ String remove_directory_from_path(String const &s) {
 	}
 	return substring(s, s.len-len, s.len);
 }
+
 String directory_from_path(String const &s) {
 	isize i = s.len-1;
 	for (; i >= 0; i--) {


### PR DESCRIPTION
Seemingly fixes the issue but introduces a *thing* where `make` will only run the demo the first time (i.e. doesn't run it if the file demo already exists). Interestingly, running `./odin run examples/demo` or `./odin run examples/demo.odin` seems to work just fine. Bizarre!
Tested on Linux